### PR TITLE
add asserts for zk deployment_id namespace

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,8 @@ fn main() {
         .get_matches();
 
     let deployment = matches.value_of("deployment").unwrap().to_owned();
+    assert!(!deployment.contains("-"));
+
     let port = value_t_or_exit!(matches, "port", u16);
     let slowlog = matches.is_present("slowlog");
     let zk_addr = matches.value_of("zk_addr").unwrap().to_owned();


### PR DESCRIPTION
Hello, 

according to : 
-  https://github.com/mit-pdos/noria/blob/master/noria-server/src/main.rs#L157
-  https://github.com/mit-pdos/noria/blob/master/noria-server/dataflow/src/lib.rs#L138

deployment id cannot include "-".

this PR forward this rule to mysql adapter.